### PR TITLE
Performance tuning - Write on demand using Pull and remove `toUnicastPublisher`

### DIFF
--- a/examples/armeria-http4s/src/main/scala/com/exmaple/http4s/armeria/ArmeriaExample.scala
+++ b/examples/armeria-http4s/src/main/scala/com/exmaple/http4s/armeria/ArmeriaExample.scala
@@ -24,7 +24,7 @@ object ArmeriaExampleApp {
     ArmeriaServerBuilder[F]
       .bindHttp(8080)
       .withMeterRegistry(registry)
-      .withHttpRoutes("/http4s", ExampleService[F].routes)
+      .withHttpRoutes("/http4s", ExampleService[F].routes())
       .withHttpService("/metrics", new PrometheusExpositionService(prometheusRegistry))
       .withDecorator(
         MetricCollectingService.newDecorator(MeterIdPrefixFunction.ofDefault("server")))

--- a/examples/armeria-http4s/src/main/scala/com/exmaple/http4s/armeria/ArmeriaExample.scala
+++ b/examples/armeria-http4s/src/main/scala/com/exmaple/http4s/armeria/ArmeriaExample.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2020 http4s.org
+ * Copyright 2020-2020 http4s.org
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/examples/armeria-http4s/src/main/scala/com/exmaple/http4s/armeria/ExampleService.scala
+++ b/examples/armeria-http4s/src/main/scala/com/exmaple/http4s/armeria/ExampleService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2020 http4s.org
+ * Copyright 2020-2020 http4s.org
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/examples/armeria-http4s/src/main/scala/com/exmaple/http4s/armeria/NoneShallPass.scala
+++ b/examples/armeria-http4s/src/main/scala/com/exmaple/http4s/armeria/NoneShallPass.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2020 http4s.org
+ * Copyright 2020-2020 http4s.org
  *
  * SPDX-License-Identifier: Apache-2.0
  */


### PR DESCRIPTION

Motivation:

The conversion between `fs2.Stream` and Reactive Streams `Publisher`
is one of the bottlenecks in that benchmark of #4

Modifications:

- Write on demand instead of `Publisher`

Result:

- Before
  ```
  Running 30s test @ http://127.0.0.1:8080/hello
    12 threads and 400 connections
    Thread Stats   Avg      Stdev     Max   +/- Stdev
      Latency    11.76ms    2.97ms  86.66ms   89.53%
        Req/Sec     1.71k     0.94k    3.64k    52.50%
    611170 requests in 30.02s, 107.62MB read
    Socket errors: connect 155, read 170, write 0, timeout 0
  Requests/sec:  20358.15
  Transfer/sec:      3.58MB
  ```
- After
  ```
  Running 30s test @ http://127.0.0.1:8080/http4s/thread
    12 threads and 400 connections
    Thread Stats   Avg      Stdev     Max   +/- Stdev
      Latency     3.77ms    2.41ms 145.85ms   96.60%
      Req/Sec     5.39k     2.88k   59.63k    60.04%
    1932651 requests in 30.10s, 312.64MB read
    Socket errors: connect 155, read 168, write 0, timeout 0
  Requests/sec:  64207.03
  Transfer/sec:     10.39MB

  Running 30s test @ http://127.0.0.1:8080/http4s/thread
    12 threads and 400 connections
    Thread Stats   Avg      Stdev     Max   +/- Stdev
      Latency     3.92ms    1.30ms  63.05ms   95.09%
      Req/Sec     5.11k     2.48k   10.36k    61.56%
    1831547 requests in 30.03s, 296.28MB read
    Socket errors: connect 155, read 160, write 0, timeout 0
  Requests/sec:  60989.03
  Transfer/sec:      9.87MBow it will be ignored.
  ```