### PR TITLE
Performance optimization for non-stream requests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,7 @@ lazy val root = project
     name := "http4s-armeria",
     description := " Armeria backend for http4s"
   )
-  .aggregate(server, client)
+  .aggregate(server, client, exampleArmeriaHttp4s, exampleArmeriaScalaPB)
 
 lazy val server = project
   .settings(publishSettings: _*)


### PR DESCRIPTION
Motivation

Better Server, Better Results

Modifications

- Batch write for a non-stream response without backpressure
  - A response having `Content-Length` header in http4s is not a stream response.
    So the response body is readily available when consuming it.
    Backpressure is meaningless in this case.
- Do not convert a request body `Publisher` to `EntityBody` if the HTTP
  method is not allowed to have a request body.
  https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods

Result

- TPS of `GET` requests with non-stream responses is increased by 10%.
- Latency is decreased by 7% 

Benchmark data
- Environment
  - iMac (Retina 5K, 27-inch, 2019) / 3 GHz 6-Core Intel Core i5
  - workload: `wrk -t12 -c400 -d30s http://127.0.0.1:8080/http4s/thread`
- working branch
```
Running 30s test @ http://127.0.0.1:8080/http4s/thread
  12 threads and 400 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    14.61ms   30.18ms 255.57ms   87.53%
    Req/Sec     8.19k     3.75k   19.10k    74.41%
  2198502 requests in 30.10s, 371.63MB read
  Socket errors: connect 155, read 83, write 28, timeout 0
Requests/sec:  73033.26
Transfer/sec:     12.35MB
```
- main branch
```
Running 30s test @ http://127.0.0.1:8080/http4s/thread
  12 threads and 400 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    15.59ms   31.36ms 285.77ms   86.94%
    Req/Sec     6.66k     3.51k   16.44k    66.41%
  1986659 requests in 30.06s, 335.82MB read
  Socket errors: connect 155, read 38, write 14, timeout 0
Requests/sec:  66095.91
Transfer/sec:     11.17MB
```