### PR TITLE
Fix version conflicts in `armeria-fs2grpc` example

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -13,4 +13,4 @@ addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.4")
 libraryDependencies += "kr.ikhoon.scalapb-reactor" %% "scalapb-reactor-codegen" % "0.3.0"
 
 // fs2-grpc
-addSbtPlugin("org.lyranthe.fs2-grpc" % "sbt-java-gen" % "1.0.1")
+addSbtPlugin("org.lyranthe.fs2-grpc" % "sbt-java-gen" % "0.11.0")


### PR DESCRIPTION
Updating version of the `fs2-grpc` plugin led to version conflicts in the `armeria-fs2grpc`:
```
[error] (exampleArmeriaFs2Grpc / update) found version conflict(s) in library dependencies; some are suspected to be binary incompatible:
[error]
[error] 	* co.fs2:fs2-core_2.13:3.0.1 (early-semver) is selected over {2.5.6, 2.5.8, 2.5.6}
[error] 	    +- org.lyranthe.fs2-grpc:java-runtime_2.13:1.0.1      (depends on 3.0.1)
[error] 	    +- org.http4s:http4s-core_2.13:0.21.24                (depends on 2.5.6)
[error] 	    +- co.fs2:fs2-reactive-streams_2.13:2.5.8             (depends on 2.5.8)
[error] 	    +- co.fs2:fs2-io_2.13:2.5.6                           (depends on 2.5.6)
[error]
[error] 	* org.typelevel:cats-effect_2.13:3.0.1 (early-semver) is selected over {2.0.0, 2.0.0, 2.5.1}
[error] 	    +- co.fs2:fs2-core_2.13:3.0.1                         (depends on 3.0.1)
[error] 	    +- org.lyranthe.fs2-grpc:java-runtime_2.13:1.0.1      (depends on 3.0.1)
[error] 	    +- org.http4s:http4s-core_2.13:0.21.24                (depends on 2.5.1)
[error] 	    +- io.chrisdavenport:vault_2.13:2.0.0                 (depends on 2.0.0)
[error] 	    +- io.chrisdavenport:unique_2.13:2.0.0                (depends on 2.0.0)
```
Because it's an example I think the dependencies could have not up-to-date versions :)