### PR TITLE
Use MUnit in examples

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -106,9 +106,8 @@ lazy val exampleArmeriaFs2Grpc = project
       "ch.qos.logback" % "logback-classic" % versions.logback % Runtime,
       "com.linecorp.armeria" % "armeria-grpc" % versions.armeria,
       "com.linecorp.armeria" %% "armeria-scalapb" % versions.armeria,
-      "org.http4s" %% "http4s-dsl" % versions.http4s,
-      "org.scalatest" %% "scalatest" % versions.scalaTest % Test
-    )
+      "org.http4s" %% "http4s-dsl" % versions.http4s
+    ) ++ munit
   )
   .enablePlugins(PrivateProjectPlugin, Fs2Grpc)
   .dependsOn(server)

--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,6 @@ val versions = new {
   val http4s = "0.21.24"
   val logback = "1.2.3"
   val micrometer = "1.7.1"
-  val scalaTest = "3.2.9"
   val munit = "0.7.27"
   val catsEffectMunit = "1.0.5"
 }

--- a/build.sbt
+++ b/build.sbt
@@ -87,9 +87,8 @@ lazy val exampleArmeriaScalaPB = project
       "ch.qos.logback" % "logback-classic" % versions.logback % Runtime,
       "com.linecorp.armeria" % "armeria-grpc" % versions.armeria,
       "com.linecorp.armeria" %% "armeria-scalapb" % versions.armeria,
-      "org.http4s" %% "http4s-dsl" % versions.http4s,
-      "org.scalatest" %% "scalatest" % versions.scalaTest % Test
-    ),
+      "org.http4s" %% "http4s-dsl" % versions.http4s
+    ) ++ munit,
     Compile / PB.targets := Seq(
       scalapb.gen() -> (Compile / sourceManaged).value,
       scalapb.reactor.ReactorCodeGenerator -> (Compile / sourceManaged).value

--- a/examples/armeria-fs2grpc/src/test/scala/com/example/fs2grpc/armeria/HelloServiceTest.scala
+++ b/examples/armeria-fs2grpc/src/test/scala/com/example/fs2grpc/armeria/HelloServiceTest.scala
@@ -6,77 +6,78 @@
 
 package com.example.fs2grpc.armeria
 
-import cats.effect.{ContextShift, IO}
+import cats.effect.IO
 import com.linecorp.armeria.client.Clients
 import com.linecorp.armeria.client.grpc.{GrpcClientOptions, GrpcClientStubFactory}
 import example.armeria.grpc.hello.{HelloReply, HelloRequest, HelloServiceFs2Grpc, HelloServiceGrpc}
 import io.grpc.{Channel, Metadata, ServiceDescriptor}
 import fs2._
-import org.scalatest.BeforeAndAfterAll
-import org.scalatest.funsuite.AnyFunSuite
-import org.scalatest.matchers.must.Matchers
-import scala.concurrent.ExecutionContext
+import munit.CatsEffectSuite
 
-class HelloServiceTest extends AnyFunSuite with BeforeAndAfterAll with Matchers {
+class HelloServiceTest extends CatsEffectSuite {
+  private def setUp() =
+    Main.newServer(0).map { armeriaServer =>
+      val httpPort = armeriaServer.server.activeLocalPort()
 
-  implicit val ec: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
+      Clients
+        .builder(s"gproto+http://127.0.0.1:$httpPort/grpc/")
+        .option(GrpcClientOptions.GRPC_CLIENT_STUB_FACTORY.newValue(new GrpcClientStubFactory {
 
-  private var releaseToken: IO[Unit] = _
-  private var httpPort: Int = _
-  private var client: HelloServiceFs2Grpc[IO, Metadata] = _
+          override def findServiceDescriptor(clientType: Class[_]): ServiceDescriptor =
+            HelloServiceGrpc.SERVICE
 
-  override protected def beforeAll(): Unit = {
-    val (armeriaServer, token) = Main.newServer(0).allocated.unsafeRunSync()
-    httpPort = armeriaServer.server.activeLocalPort()
-    releaseToken = token
+          override def newClientStub(clientType: Class[_], channel: Channel): AnyRef =
+            HelloServiceFs2Grpc.stub[IO](channel)
 
-    client = Clients
-      .builder(s"gproto+http://127.0.0.1:$httpPort/grpc/")
-      .option(GrpcClientOptions.GRPC_CLIENT_STUB_FACTORY.newValue(new GrpcClientStubFactory {
+        }))
+        .build(classOf[HelloServiceFs2Grpc[IO, Metadata]])
+    }
 
-        override def findServiceDescriptor(clientType: Class[_]): ServiceDescriptor =
-          HelloServiceGrpc.SERVICE
+  private val fixture = ResourceSuiteLocalFixture("fixture", setUp())
 
-        override def newClientStub(clientType: Class[_], channel: Channel): AnyRef =
-          HelloServiceFs2Grpc.stub[IO](channel)
-
-      }))
-      .build(classOf[HelloServiceFs2Grpc[IO, Metadata]])
-  }
-
-  override protected def afterAll(): Unit = releaseToken.unsafeRunSync()
+  override def munitFixtures = List(fixture)
 
   val message = "ScalaPB with Reactor"
+
   test("unary") {
-    val response = client.unary(HelloRequest(message), new Metadata()).unsafeRunSync()
-    response.message must be(s"Hello $message!")
+    val client = fixture()
+    val response = client.unary(HelloRequest(message), new Metadata())
+    assertIO(response.map(_.message), s"Hello $message!")
   }
 
   test("serverStream") {
+    val client = fixture()
+
     val response = client
       .serverStreaming(HelloRequest(message), new Metadata())
       .compile
       .toVector
-      .unsafeRunSync()
-    val expected = (1 to 5).map(i => HelloReply(s"Hello $message $i!"))
-    response must be(expected)
+
+    val expected = (1 to 5).map(i => HelloReply(s"Hello $message $i!")).toVector
+
+    assertIO(response, expected)
   }
 
   test("clientStream") {
+    val client = fixture()
+
     val response = client
       .clientStreaming(Stream.range(1, 6).map(i => HelloRequest(i.toString)), new Metadata())
-      .unsafeRunSync()
-    response.message must be("Hello 1, 2, 3, 4, 5!")
+
+    assertIO(response.map(_.message), "Hello 1, 2, 3, 4, 5!")
   }
 
   test("bidiStream") {
+    val client = fixture()
+
     val responses = client
       .bidiStreaming(Stream(1, 2, 3).map(i => HelloRequest(i.toString)), new Metadata())
       .map(res => res.message)
       .compile
       .toVector
-      .unsafeRunSync()
-    val expected = (1 to 3).map(i => s"Hello $i!")
-    responses must be(expected)
+
+    val expected = (1 to 3).map(i => s"Hello $i!").toVector
+
+    assertIO(responses, expected)
   }
 }

--- a/examples/armeria-scalapb/src/test/scala/com/example/scalapb/armeria/HelloServiceTest.scala
+++ b/examples/armeria-scalapb/src/test/scala/com/example/scalapb/armeria/HelloServiceTest.scala
@@ -15,7 +15,7 @@ import reactor.core.scala.publisher.SFlux
 import scala.concurrent.duration.DurationInt
 
 class HelloServiceTest extends CatsEffectSuite {
-  private def setUp() = {
+  private def setUp() =
     Main.newServer(0).map { armeriaServer =>
       val httpPort = armeriaServer.server.activeLocalPort()
 
@@ -23,7 +23,6 @@ class HelloServiceTest extends CatsEffectSuite {
         .builder(s"gproto+http://127.0.0.1:$httpPort/grpc/")
         .build(classOf[ReactorHelloServiceStub])
     }
-  }
 
   private val fixture = ResourceSuiteLocalFixture("fixture", setUp())
 

--- a/examples/armeria-scalapb/src/test/scala/com/example/scalapb/armeria/HelloServiceTest.scala
+++ b/examples/armeria-scalapb/src/test/scala/com/example/scalapb/armeria/HelloServiceTest.scala
@@ -6,50 +6,46 @@
 
 package com.example.scalapb.armeria
 
-import cats.effect.{ContextShift, IO}
 import com.linecorp.armeria.client.Clients
 import example.armeria.grpc.hello.ReactorHelloServiceGrpc.ReactorHelloServiceStub
 import example.armeria.grpc.hello.{HelloReply, HelloRequest}
-import org.scalatest.BeforeAndAfterAll
-import org.scalatest.funsuite.AnyFunSuite
-import org.scalatest.matchers.must.Matchers
+import munit.CatsEffectSuite
 import reactor.core.scala.publisher.SFlux
-import scala.concurrent.ExecutionContext
+
 import scala.concurrent.duration.DurationInt
 
-class HelloServiceTest extends AnyFunSuite with BeforeAndAfterAll with Matchers {
+class HelloServiceTest extends CatsEffectSuite {
+  private def setUp() = {
+    Main.newServer(0).map { armeriaServer =>
+      val httpPort = armeriaServer.server.activeLocalPort()
 
-  implicit val ec: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
-
-  private var releaseToken: IO[Unit] = _
-  private var httpPort: Int = _
-  private var client: ReactorHelloServiceStub = _
-
-  override protected def beforeAll(): Unit = {
-    val (armeriaServer, token) = Main.newServer(0).allocated.unsafeRunSync()
-    httpPort = armeriaServer.server.activeLocalPort()
-    releaseToken = token
-
-    client = Clients
-      .builder(s"gproto+http://127.0.0.1:$httpPort/grpc/")
-      .build(classOf[ReactorHelloServiceStub])
+      Clients
+        .builder(s"gproto+http://127.0.0.1:$httpPort/grpc/")
+        .build(classOf[ReactorHelloServiceStub])
+    }
   }
 
-  override protected def afterAll(): Unit = releaseToken.unsafeRunSync()
+  private val fixture = ResourceSuiteLocalFixture("fixture", setUp())
+
+  override def munitFixtures = List(fixture)
 
   val message = "ScalaPB with Reactor"
+
   test("unary") {
+    val client = fixture()
     val response = client.unary(HelloRequest(message)).block()
-    response.message must be(s"Hello $message!")
+    assertEquals(response.message, s"Hello $message!")
   }
 
   test("serverStream") {
+    val client = fixture()
     val response = client.serverStreaming(HelloRequest(message)).collectSeq().block()
     val expected = (1 to 5).map(i => HelloReply(s"Hello $message $i!"))
-    response must be(expected)
+    assertEquals(response, expected)
   }
 
   test("clientStream") {
+    val client = fixture()
     val response = client
       .clientStreaming(
         SFlux
@@ -58,16 +54,17 @@ class HelloServiceTest extends AnyFunSuite with BeforeAndAfterAll with Matchers 
           .map(i => HelloRequest(i.toString))
       )
       .block()
-    response.message must be("Hello 1, 2, 3, 4, 5!")
+    assertEquals(response.message, "Hello 1, 2, 3, 4, 5!")
   }
 
   test("bidiStream") {
+    val client = fixture()
     val responses = client
       .bidiStreaming(SFlux(1, 2, 3).map(i => HelloRequest(i.toString)))
       .map(res => res.message)
       .collectSeq()
       .block()
     val expected = (1 to 3).map(i => s"Hello $i!")
-    responses must be(expected)
+    assertEquals(responses, expected)
   }
 }


### PR DESCRIPTION
A final migration on MUnit in tests.
N. B.: some test suites fail in `armeria-fs2grpc` on the previous scalatest based tests and brand-new MUnit based tests. I've tried to figure out what's wrong - and not found out, unfortunately.