### PR TITLE
Use new sbt syntax in version.sbt

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.2.1-SNAPSHOT"
+ThisBuild / version := "0.2.1-SNAPSHOT"


### PR DESCRIPTION
Method `in` in trait `ScopingSetting` is deprecated (since 1.5.0).