### PR TITLE
Set up `series/0.2` branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,15 +130,15 @@ jobs:
         run: sbt '++${{ matrix.scala }}' unusedCompileDependenciesTest
 
       - name: Make target directories
-        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
+        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/series/0.2')
         run: mkdir -p server/target target examples/armeria-fs2grpc/target client/target examples/armeria-http4s/target examples/armeria-scalapb/target project/target
 
       - name: Compress target directories
-        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
+        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/series/0.2')
         run: tar cf targets.tar server/target target examples/armeria-fs2grpc/target client/target examples/armeria-http4s/target examples/armeria-scalapb/target project/target
 
       - name: Upload target directories
-        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
+        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/series/0.2')
         uses: actions/upload-artifact@v2
         with:
           name: target-${{ matrix.os }}-${{ matrix.java }}-${{ matrix.scala }}
@@ -147,7 +147,7 @@ jobs:
   publish:
     name: Publish Artifacts
     needs: [build]
-    if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
+    if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/series/0.2')
     strategy:
       matrix:
         os: [ubuntu-latest]

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import sbt.Keys.{libraryDependencies, sourceManaged}
 import sbtprotoc.ProtocPlugin.autoImport.PB
 
-ThisBuild / tlBaseVersion := "0.3"
+ThisBuild / tlBaseVersion := "0.2"
 ThisBuild / developers := List(
   Developer(
     "ikhoon",
@@ -12,7 +12,7 @@ ThisBuild / developers := List(
 )
 ThisBuild / crossScalaVersions := Seq("2.13.8", "2.12.16")
 ThisBuild / scalaVersion := crossScalaVersions.value.head
-ThisBuild / tlCiReleaseBranches := Seq("main")
+ThisBuild / tlCiReleaseBranches := Seq("series/0.2")
 ThisBuild / homepage := Some(url("https://github.com/http4s/http4s-armeria"))
 ThisBuild / licenses := List("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0"))
 ThisBuild / startYear := Some(2020)
@@ -21,8 +21,8 @@ ThisBuild / Test / javaOptions += "-Dcom.linecorp.armeria.verboseResponses=true 
 
 val versions = new {
   val armeria = "1.17.1"
-  val fs2 = "3.2.10"
-  val http4s = "0.23.13"
+  val fs2 = "2.5.11"
+  val http4s = "0.22.14"
   val logback = "1.2.11"
   val micrometer = "1.9.2"
   val munit = "0.7.29"
@@ -31,7 +31,7 @@ val versions = new {
 
 val munit = Seq(
   "org.scalameta" %% "munit" % versions.munit % Test,
-  "org.typelevel" %% "munit-cats-effect-3" % versions.catsEffectMunit % Test
+  "org.typelevel" %% "munit-cats-effect-2" % versions.catsEffectMunit % Test
 )
 
 lazy val root = project

--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,4 @@
+import com.typesafe.tools.mima.core.{IncompatibleResultTypeProblem, ProblemFilters}
 import sbt.Keys.{libraryDependencies, sourceManaged}
 import sbtprotoc.ProtocPlugin.autoImport.PB
 
@@ -53,7 +54,11 @@ lazy val server = project
       "org.http4s" %% "http4s-server" % versions.http4s,
       "ch.qos.logback" % "logback-classic" % versions.logback % Test,
       "org.http4s" %% "http4s-dsl" % versions.http4s % Test
-    ) ++ munit
+    ) ++ munit,
+    mimaBinaryIssueFilters ++= Seq(
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("org.http4s.armeria.server.ServiceRequestContexts.Key"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("org.http4s.armeria.server.ServiceRequestContexts.Key")
+    )
   )
 
 lazy val client = project

--- a/build.sbt
+++ b/build.sbt
@@ -56,8 +56,10 @@ lazy val server = project
       "org.http4s" %% "http4s-dsl" % versions.http4s % Test
     ) ++ munit,
     mimaBinaryIssueFilters ++= Seq(
-      ProblemFilters.exclude[IncompatibleResultTypeProblem]("org.http4s.armeria.server.ServiceRequestContexts.Key"),
-      ProblemFilters.exclude[IncompatibleResultTypeProblem]("org.http4s.armeria.server.ServiceRequestContexts.Key")
+      ProblemFilters.exclude[IncompatibleResultTypeProblem](
+        "org.http4s.armeria.server.ServiceRequestContexts.Key"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem](
+        "org.http4s.armeria.server.ServiceRequestContexts.Key")
     )
   )
 

--- a/client/src/test/scala/org/http4s/armeria/client/ArmeriaClientSuite.scala
+++ b/client/src/test/scala/org/http4s/armeria/client/ArmeriaClientSuite.scala
@@ -74,7 +74,7 @@ class ArmeriaClientSuite extends CatsEffectSuite {
         new HttpService {
           override def serve(ctx: ServiceRequestContext, req: HttpRequest): HttpResponse = {
             val body: IO[Option[String]] = req
-              .toStreamBuffered[IO](1)
+              .toStream[IO]
               .collect { case data: HttpData => data.toStringUtf8 }
               .reduce(_ + " " + _)
               .compile
@@ -100,7 +100,7 @@ class ArmeriaClientSuite extends CatsEffectSuite {
             val writer = HttpResponse.streaming()
             writer.write(ResponseHeaders.of(HttpStatus.OK))
             req
-              .toStreamBuffered[IO](1)
+              .toStream[IO]
               .collect { case data: HttpData =>
                 writer.write(HttpData.ofUtf8(s"${data.toStringUtf8}!"))
               }
@@ -179,7 +179,7 @@ class ArmeriaClientSuite extends CatsEffectSuite {
       .range(1, 6)
       .covary[IO]
       .map(_.toString)
-      .through(text.utf8.encode)
+      .through(text.utf8Encode)
 
     val req = Request(method = Method.POST, uri = uri"/client-streaming", body = body)
     val response = client.expect[String](IO(req)).unsafeRunSync()
@@ -193,7 +193,7 @@ class ArmeriaClientSuite extends CatsEffectSuite {
       .range(1, 6)
       .covary[IO]
       .map(_.toString)
-      .through(text.utf8.encode)
+      .through(text.utf8Encode)
 
     val req = Request(method = Method.POST, uri = uri"/bidi-streaming", body = body)
     val response = client
@@ -203,6 +203,6 @@ class ArmeriaClientSuite extends CatsEffectSuite {
       .toList
       .unsafeRunSync()
       .reduce(_ + " " + _)
-    assertEquals(response, "1! 2! 3! 4! 5!")
+    assertEquals(response, "1! 2! 3! 4! 5! ")
   }
 }

--- a/examples/armeria-http4s/src/main/scala/com/exmaple/http4s/armeria/ExampleService.scala
+++ b/examples/armeria-http4s/src/main/scala/com/exmaple/http4s/armeria/ExampleService.scala
@@ -16,7 +16,7 @@ import org.http4s.armeria.server.ServiceRequestContexts
 import org.http4s.dsl.Http4sDsl
 import scala.concurrent.duration._
 
-class ExampleService[F[_]](implicit F: ConcurrentEffect[F], t: Timer[F]) extends Http4sDsl[F] {
+class ExampleService[F[_]](implicit F: ConcurrentEffect[F], T: Timer[F]) extends Http4sDsl[F] {
 
   def routes(): HttpRoutes[F] =
     HttpRoutes.of[F] {

--- a/examples/armeria-http4s/src/main/scala/com/exmaple/http4s/armeria/ExampleService.scala
+++ b/examples/armeria-http4s/src/main/scala/com/exmaple/http4s/armeria/ExampleService.scala
@@ -16,7 +16,7 @@ import org.http4s.armeria.server.ServiceRequestContexts
 import org.http4s.dsl.Http4sDsl
 import scala.concurrent.duration._
 
-class ExampleService[F[_]](implicit F: Async[F]) extends Http4sDsl[F] {
+class ExampleService[F[_]](implicit F: ConcurrentEffect[F], t: Timer[F]) extends Http4sDsl[F] {
 
   def routes(): HttpRoutes[F] =
     HttpRoutes.of[F] {
@@ -51,5 +51,5 @@ class ExampleService[F[_]](implicit F: Async[F]) extends Http4sDsl[F] {
 }
 
 object ExampleService {
-  def apply[F[_]: Async] = new ExampleService[F]
+  def apply[F[_]: ConcurrentEffect: Timer] = new ExampleService[F]
 }

--- a/examples/armeria-http4s/src/main/scala/com/exmaple/http4s/armeria/Main.scala
+++ b/examples/armeria-http4s/src/main/scala/com/exmaple/http4s/armeria/Main.scala
@@ -18,7 +18,7 @@ object ArmeriaExample extends IOApp {
 }
 
 object ArmeriaExampleApp {
-  def builder[F[_]: Async]: ArmeriaServerBuilder[F] = {
+  def builder[F[_]: ConcurrentEffect: Timer]: ArmeriaServerBuilder[F] = {
     val registry = PrometheusMeterRegistries.newRegistry()
     val prometheusRegistry = registry.getPrometheusRegistry
     ArmeriaServerBuilder[F]
@@ -31,6 +31,6 @@ object ArmeriaExampleApp {
       .withDecoratorUnder("/black-knight", new NoneShallPass(_))
   }
 
-  def resource[F[_]: Async]: Resource[F, ArmeriaServer] =
+  def resource[F[_]: ConcurrentEffect: Timer]: Resource[F, ArmeriaServer] =
     builder[F].resource
 }

--- a/examples/armeria-scalapb/src/main/scala/com/example/scalapb/armeria/ExampleService.scala
+++ b/examples/armeria-scalapb/src/main/scala/com/example/scalapb/armeria/ExampleService.scala
@@ -25,7 +25,7 @@ import org.http4s.armeria.server.ServiceRequestContexts
 import org.http4s.dsl.Http4sDsl
 import scala.concurrent.duration._
 
-class ExampleService[F[_]](implicit F: Async[F]) extends Http4sDsl[F] {
+class ExampleService[F[_]](implicit F: ConcurrentEffect[F], t: Timer[F]) extends Http4sDsl[F] {
 
   def routes(): HttpRoutes[F] =
     HttpRoutes.of[F] {
@@ -60,5 +60,5 @@ class ExampleService[F[_]](implicit F: Async[F]) extends Http4sDsl[F] {
 }
 
 object ExampleService {
-  def apply[F[_]: Async] = new ExampleService[F]
+  def apply[F[_]: ConcurrentEffect: Timer] = new ExampleService[F]
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,4 +9,4 @@ addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.6")
 libraryDependencies += "kr.ikhoon.scalapb-reactor" %% "scalapb-reactor-codegen" % "0.3.0"
 
 // fs2-grpc
-addSbtPlugin("org.lyranthe.fs2-grpc" % "sbt-java-gen" % "1.0.1")
+addSbtPlugin("org.lyranthe.fs2-grpc" % "sbt-java-gen" % "0.11.2")

--- a/server/src/main/scala/org/http4s/armeria/server/ArmeriaServerBuilder.scala
+++ b/server/src/main/scala/org/http4s/armeria/server/ArmeriaServerBuilder.scala
@@ -16,10 +16,8 @@
 
 package org.http4s.armeria.server
 
-import cats.effect.{Async, Resource}
-import cats.syntax.applicative._
-import cats.syntax.flatMap._
-import cats.syntax.functor._
+import cats.effect.{ConcurrentEffect, Resource}
+import cats.implicits._
 import com.linecorp.armeria.common.util.Version
 import com.linecorp.armeria.common.{HttpRequest, HttpResponse, SessionProtocol}
 import com.linecorp.armeria.server.{
@@ -38,10 +36,7 @@ import java.net.InetSocketAddress
 import java.security.PrivateKey
 import java.security.cert.X509Certificate
 import java.util.function.{Function => JFunction}
-
-import cats.effect.std.Dispatcher
 import javax.net.ssl.KeyManagerFactory
-import org.http4s.armeria.server.ArmeriaServerBuilder.AddServices
 import org.http4s.{BuildInfo, HttpApp, HttpRoutes}
 import org.http4s.server.{
   DefaultServiceErrorHandler,
@@ -53,21 +48,21 @@ import org.http4s.server.{
 import org.http4s.server.defaults.{IdleTimeout, ResponseTimeout, ShutdownTimeout}
 import org.http4s.syntax.all._
 import org.log4s.{Logger, getLogger}
-
 import scala.collection.immutable
 import scala.concurrent.duration.FiniteDuration
 
 sealed class ArmeriaServerBuilder[F[_]] private (
-    addServices: AddServices[F],
+    armeriaServerBuilder: ArmeriaBuilder,
     socketAddress: InetSocketAddress,
     serviceErrorHandler: ServiceErrorHandler[F],
-    banner: List[String])(implicit protected val F: Async[F])
+    banner: List[String]
+)(implicit protected val F: ConcurrentEffect[F])
     extends ServerBuilder[F] {
   override type Self = ArmeriaServerBuilder[F]
 
-  type DecoratingFunction = (HttpService, ServiceRequestContext, HttpRequest) => HttpResponse
-
   private[this] val logger: Logger = getLogger
+
+  type DecoratingFunction = (HttpService, ServiceRequestContext, HttpRequest) => HttpResponse
 
   override def bindSocketAddress(socketAddress: InetSocketAddress): Self =
     copy(socketAddress = socketAddress)
@@ -76,45 +71,35 @@ sealed class ArmeriaServerBuilder[F[_]] private (
     copy(serviceErrorHandler = serviceErrorHandler)
 
   override def resource: Resource[F, ArmeriaServer] =
-    Dispatcher[F].flatMap { dispatcher =>
-      Resource(for {
-        defaultServerBuilder <- F.delay {
-          BackendServer
-            .builder()
-            .idleTimeoutMillis(IdleTimeout.toMillis)
-            .requestTimeoutMillis(ResponseTimeout.toMillis)
-            .gracefulShutdownTimeoutMillis(ShutdownTimeout.toMillis, ShutdownTimeout.toMillis)
+    Resource(F.delay {
+      val armeriaServer0 = armeriaServerBuilder
+        .http(socketAddress)
+        .build()
+
+      armeriaServer0.addListener(new ServerListenerAdapter {
+        override def serverStarting(server: BackendServer): Unit = {
+          banner.foreach(logger.info(_))
+
+          val armeriaVersion = Version.get("armeria").artifactVersion()
+
+          logger.info(s"http4s v${BuildInfo.version} on Armeria v$armeriaVersion started")
         }
-        builderWithServices <- addServices(defaultServerBuilder, dispatcher)
-        res <- F.delay {
-          val armeriaServer0 = builderWithServices.http(socketAddress).build()
+      })
+      armeriaServer0.start().join()
 
-          armeriaServer0.addListener(new ServerListenerAdapter {
-            override def serverStarting(server: BackendServer): Unit = {
-              banner.foreach(logger.info(_))
-
-              val armeriaVersion = Version.get("armeria").artifactVersion()
-
-              logger.info(s"http4s v${BuildInfo.version} on Armeria v$armeriaVersion started")
-            }
-          })
-          armeriaServer0.start().join()
-
-          val armeriaServer: ArmeriaServer = new ArmeriaServer {
-            lazy val address: InetSocketAddress = {
-              val host = socketAddress.getHostString
-              val port = server.activeLocalPort()
-              new InetSocketAddress(host, port)
-            }
-
-            lazy val server: BackendServer = armeriaServer0
-            lazy val isSecure: Boolean = server.activePort(SessionProtocol.HTTPS) != null
-          }
-
-          armeriaServer -> shutdown(armeriaServer.server)
+      val armeriaServer: ArmeriaServer = new ArmeriaServer {
+        lazy val address: InetSocketAddress = {
+          val host = socketAddress.getHostString
+          val port = server.activeLocalPort()
+          new InetSocketAddress(host, port)
         }
-      } yield res)
-    }
+
+        lazy val server: BackendServer = armeriaServer0
+        lazy val isSecure: Boolean = server.activePort(SessionProtocol.HTTPS) != null
+      }
+
+      armeriaServer -> shutdown(armeriaServer.server)
+    })
 
   /** Binds the specified `service` at the specified path pattern. See
     * [[https://armeria.dev/docs/server-basics#path-patterns]] for detailed information of path
@@ -122,85 +107,108 @@ sealed class ArmeriaServerBuilder[F[_]] private (
     */
   def withHttpService(
       pathPattern: String,
-      service: (ServiceRequestContext, HttpRequest) => HttpResponse): Self =
-    atBuild(
-      _.service(
-        pathPattern,
-        new HttpService {
-          override def serve(ctx: ServiceRequestContext, req: HttpRequest): HttpResponse =
-            service(ctx, req)
-        }))
+      service: (ServiceRequestContext, HttpRequest) => HttpResponse): Self = {
+    armeriaServerBuilder.service(
+      pathPattern,
+      new HttpService {
+        override def serve(ctx: ServiceRequestContext, req: HttpRequest): HttpResponse =
+          service(ctx, req)
+      })
+    this
+  }
 
   /** Binds the specified [[com.linecorp.armeria.server.HttpService]] at the specified path pattern.
     * See [[https://armeria.dev/docs/server-basics#path-patterns]] for detailed information of path
     * pattens.
     */
-  def withHttpService(pathPattern: String, service: HttpService): Self =
-    atBuild(_.service(pathPattern, service))
+  def withHttpService(pathPattern: String, service: HttpService): Self = {
+    armeriaServerBuilder.service(pathPattern, service)
+    this
+  }
 
   /** Binds the specified [[com.linecorp.armeria.server.HttpServiceWithRoutes]] at multiple
     * [[com.linecorp.armeria.server.Route]] s of the default
     * [[com.linecorp.armeria.server.VirtualHost]].
     */
-  def withHttpService(serviceWithRoutes: HttpServiceWithRoutes): Self =
-    atBuild(_.service(serviceWithRoutes))
+  def withHttpService(serviceWithRoutes: HttpServiceWithRoutes): Self = {
+    armeriaServerBuilder.service(serviceWithRoutes)
+    this
+  }
 
   /** Binds the specified [[com.linecorp.armeria.server.HttpService]] under the specified directory.
     */
-  def withHttpServiceUnder(prefix: String, service: HttpService): Self =
-    atBuild(_.serviceUnder(prefix, service))
+  def withHttpServiceUnder(prefix: String, service: HttpService): Self = {
+    armeriaServerBuilder.serviceUnder(prefix, service)
+    this
+  }
 
   /** Binds the specified [[org.http4s.HttpRoutes]] under the specified prefix. */
   def withHttpRoutes(prefix: String, service: HttpRoutes[F]): Self =
     withHttpApp(prefix, service.orNotFound)
 
   /** Binds the specified [[org.http4s.HttpApp]] under the specified prefix. */
-  def withHttpApp(prefix: String, service: HttpApp[F]): Self =
-    copy(addServices = (ab, dispatcher) =>
-      addServices(ab, dispatcher).map(
-        _.serviceUnder(prefix, ArmeriaHttp4sHandler(prefix, service, dispatcher))))
+  def withHttpApp(prefix: String, service: HttpApp[F]): Self = {
+    armeriaServerBuilder.serviceUnder(prefix, ArmeriaHttp4sHandler(prefix, service))
+    this
+  }
 
   /** Decorates all HTTP services with the specified [[DecoratingFunction]]. */
-  def withDecorator(decorator: DecoratingFunction): Self =
-    atBuild(_.decorator((delegate, ctx, req) => decorator(delegate, ctx, req)))
+  def withDecorator(decorator: DecoratingFunction): Self = {
+    armeriaServerBuilder.decorator((delegate, ctx, req) => decorator(delegate, ctx, req))
+    this
+  }
 
   /** Decorates all HTTP services with the specified `decorator`. */
-  def withDecorator(decorator: JFunction[_ >: HttpService, _ <: HttpService]): Self =
-    atBuild(_.decorator(decorator))
+  def withDecorator(decorator: JFunction[_ >: HttpService, _ <: HttpService]): Self = {
+    armeriaServerBuilder.decorator(decorator)
+    this
+  }
 
   /** Decorates HTTP services under the specified directory with the specified
     * [[DecoratingFunction]].
     */
-  def withDecoratorUnder(prefix: String, decorator: DecoratingFunction): Self =
-    atBuild(_.decoratorUnder(prefix, (delegate, ctx, req) => decorator(delegate, ctx, req)))
+  def withDecoratorUnder(prefix: String, decorator: DecoratingFunction): Self = {
+    armeriaServerBuilder.decoratorUnder(
+      prefix,
+      (delegate, ctx, req) => decorator(delegate, ctx, req))
+    this
+  }
 
   /** Decorates HTTP services under the specified directory with the specified `decorator`. */
   def withDecoratorUnder(
       prefix: String,
-      decorator: JFunction[_ >: HttpService, _ <: HttpService]): Self =
-    atBuild(_.decoratorUnder(prefix, decorator))
+      decorator: JFunction[_ >: HttpService, _ <: HttpService]): Self = {
+    armeriaServerBuilder.decoratorUnder(prefix, decorator)
+    this
+  }
 
   /** Configures the Armeria server using the specified
     * [[com.linecorp.armeria.server.ServerBuilder]].
     */
-  def withArmeriaBuilder(customizer: ArmeriaBuilder => Unit): Self =
-    atBuild { ab => customizer(ab); ab }
+  def withArmeriaBuilder(customizer: ArmeriaBuilder => Unit): Self = {
+    customizer(armeriaServerBuilder)
+    this
+  }
 
   /** Sets the idle timeout of a connection in milliseconds for keep-alive.
     *
     * @param idleTimeout
     *   the timeout. `scala.concurrent.duration.Duration.Zero` disables the timeout.
     */
-  def withIdleTimeout(idleTimeout: FiniteDuration): Self =
-    atBuild(_.idleTimeoutMillis(idleTimeout.toMillis))
+  def withIdleTimeout(idleTimeout: FiniteDuration): Self = {
+    armeriaServerBuilder.idleTimeoutMillis(idleTimeout.toMillis)
+    this
+  }
 
   /** Sets the timeout of a request.
     *
     * @param requestTimeout
     *   the timeout. `scala.concurrent.duration.Duration.Zero` disables the timeout.
     */
-  def withRequestTimeout(requestTimeout: FiniteDuration): Self =
-    atBuild(_.requestTimeoutMillis(requestTimeout.toMillis))
+  def withRequestTimeout(requestTimeout: FiniteDuration): Self = {
+    armeriaServerBuilder.requestTimeoutMillis(requestTimeout.toMillis)
+    this
+  }
 
   /** Adds an HTTP port that listens on all available network interfaces.
     *
@@ -209,7 +217,10 @@ sealed class ArmeriaServerBuilder[F[_]] private (
     * @see
     *   [[com.linecorp.armeria.server.ServerBuilder#https(localAddress:java\.net\.InetSocketAddress):com\.linecorp\.armeria\.server\.ServerBuilder*]]
     */
-  def withHttp(port: Int): Self = atBuild(_.http(port))
+  def withHttp(port: Int): Self = {
+    armeriaServerBuilder.http(port)
+    this
+  }
 
   /** Adds an HTTPS port that listens on all available network interfaces.
     *
@@ -218,7 +229,10 @@ sealed class ArmeriaServerBuilder[F[_]] private (
     * @see
     *   [[com.linecorp.armeria.server.ServerBuilder#https(localAddress:java\.net\.InetSocketAddress):com\.linecorp\.armeria\.server\.ServerBuilder*]]
     */
-  def withHttps(port: Int): Self = atBuild(_.https(port))
+  def withHttps(port: Int): Self = {
+    armeriaServerBuilder.https(port)
+    this
+  }
 
   /** Sets the [[io.netty.channel.ChannelOption]] of the server socket bound by
     * [[com.linecorp.armeria.server.Server]]. Note that the previously added option will be
@@ -227,8 +241,10 @@ sealed class ArmeriaServerBuilder[F[_]] private (
     * @see
     *   [[https://armeria.dev/docs/advanced-production-checklist Production checklist]]
     */
-  def withChannelOption[T](option: ChannelOption[T], value: T): Self =
-    atBuild(_.channelOption(option, value))
+  def withChannelOption[T](option: ChannelOption[T], value: T): Self = {
+    armeriaServerBuilder.channelOption(option, value)
+    this
+  }
 
   /** Sets the [[io.netty.channel.ChannelOption]] of sockets accepted by
     * [[com.linecorp.armeria.server.Server]]. Note that the previously added option will be
@@ -237,8 +253,10 @@ sealed class ArmeriaServerBuilder[F[_]] private (
     * @see
     *   [[https://armeria.dev/docs/advanced-production-checklist Production checklist]]
     */
-  def withChildChannelOption[T](option: ChannelOption[T], value: T): Self =
-    atBuild(_.childChannelOption(option, value))
+  def withChildChannelOption[T](option: ChannelOption[T], value: T): Self = {
+    armeriaServerBuilder.childChannelOption(option, value)
+    this
+  }
 
   /** Configures SSL or TLS of this [[com.linecorp.armeria.server.Server]] from the specified
     * `keyCertChainFile`, `keyFile` and `keyPassword`.
@@ -246,8 +264,10 @@ sealed class ArmeriaServerBuilder[F[_]] private (
     * @see
     *   [[withTlsCustomizer]]
     */
-  def withTls(keyCertChainFile: File, keyFile: File, keyPassword: Option[String]): Self =
-    atBuild(_.tls(keyCertChainFile, keyFile, keyPassword.orNull))
+  def withTls(keyCertChainFile: File, keyFile: File, keyPassword: Option[String]): Self = {
+    armeriaServerBuilder.tls(keyCertChainFile, keyFile, keyPassword.orNull)
+    this
+  }
 
   /** Configures SSL or TLS of this [[com.linecorp.armeria.server.Server]] with the specified
     * `keyCertChainInputStream`, `keyInputStream` and `keyPassword`.
@@ -258,17 +278,14 @@ sealed class ArmeriaServerBuilder[F[_]] private (
   def withTls(
       keyCertChainInputStream: Resource[F, InputStream],
       keyInputStream: Resource[F, InputStream],
-      keyPassword: Option[String]): Self =
-    copy(addServices = (armeriaBuilder, dispatcher) =>
-      addServices(armeriaBuilder, dispatcher).flatMap { ab =>
-        keyCertChainInputStream
-          .both(keyInputStream)
-          .use { case (keyCertChain, key) =>
-            F.delay {
-              ab.tls(keyCertChain, key, keyPassword.orNull)
-            }
-          }
-      })
+      keyPassword: Option[String]): F[Self] =
+    (keyCertChainInputStream, keyInputStream).tupled
+      .use { case (keyCertChain, key) =>
+        F.delay {
+          armeriaServerBuilder.tls(keyCertChain, key, keyPassword.orNull)
+          this
+        }
+      }
 
   /** Configures SSL or TLS of this [[com.linecorp.armeria.server.Server]] with the specified
     * cleartext [[java.security.PrivateKey]] and [[java.security.cert.X509Certificate]] chain.
@@ -276,8 +293,10 @@ sealed class ArmeriaServerBuilder[F[_]] private (
     * @see
     *   [[withTlsCustomizer]]
     */
-  def withTls(key: PrivateKey, keyCertChain: X509Certificate*): Self =
-    atBuild(_.tls(key, keyCertChain: _*))
+  def withTls(key: PrivateKey, keyCertChain: X509Certificate*): Self = {
+    armeriaServerBuilder.tls(key, keyCertChain: _*)
+    this
+  }
 
   /** Configures SSL or TLS of this [[com.linecorp.armeria.server.Server]] with the specified
     * [[javax.net.ssl.KeyManagerFactory]].
@@ -285,14 +304,18 @@ sealed class ArmeriaServerBuilder[F[_]] private (
     * @see
     *   [[withTlsCustomizer]]
     */
-  def withTls(keyManagerFactory: KeyManagerFactory): Self =
-    atBuild(_.tls(keyManagerFactory))
+  def withTls(keyManagerFactory: KeyManagerFactory): Self = {
+    armeriaServerBuilder.tls(keyManagerFactory)
+    this
+  }
 
   /** Adds the specified `tlsCustomizer` which can arbitrarily configure the
     * [[io.netty.handler.ssl.SslContextBuilder]] that will be applied to the SSL session.
     */
-  def withTlsCustomizer(tlsCustomizer: SslContextBuilder => Unit): Self =
-    atBuild(_.tlsCustomizer(ctxBuilder => tlsCustomizer(ctxBuilder)))
+  def withTlsCustomizer(tlsCustomizer: SslContextBuilder => Unit): Self = {
+    armeriaServerBuilder.tlsCustomizer(ctxBuilder => tlsCustomizer(ctxBuilder))
+    this
+  }
 
   /** Sets the amount of time to wait after calling [[com.linecorp.armeria.server.Server#stop]] for
     * requests to go away before actually shutting down.
@@ -306,15 +329,19 @@ sealed class ArmeriaServerBuilder[F[_]] private (
     *   This should be set to a time greater than `quietPeriod` to ensure the server shuts down even
     *   if there is a stuck request.
     */
-  def withGracefulShutdownTimeout(quietPeriod: FiniteDuration, timeout: FiniteDuration): Self =
-    atBuild(_.gracefulShutdownTimeoutMillis(quietPeriod.toMillis, timeout.toMillis))
+  def withGracefulShutdownTimeout(quietPeriod: FiniteDuration, timeout: FiniteDuration): Self = {
+    armeriaServerBuilder.gracefulShutdownTimeoutMillis(quietPeriod.toMillis, timeout.toMillis)
+    this
+  }
 
   /** Sets the [[io.micrometer.core.instrument.MeterRegistry]] that collects various stats. */
-  def withMeterRegistry(meterRegistry: MeterRegistry): Self =
-    atBuild(_.meterRegistry(meterRegistry))
+  def withMeterRegistry(meterRegistry: MeterRegistry): Self = {
+    armeriaServerBuilder.meterRegistry(meterRegistry)
+    this
+  }
 
   private def shutdown(armeriaServer: BackendServer): F[Unit] =
-    F.async_[Unit] { cb =>
+    F.async[Unit] { cb =>
       val _ = armeriaServer
         .stop()
         .whenComplete { (_, cause) =>
@@ -328,16 +355,12 @@ sealed class ArmeriaServerBuilder[F[_]] private (
   override def withBanner(banner: immutable.Seq[String]): Self = copy(banner = banner.toList)
 
   private def copy(
-      addServices: AddServices[F] = addServices,
+      armeriaServerBuilder: ArmeriaBuilder = armeriaServerBuilder,
       socketAddress: InetSocketAddress = socketAddress,
       serviceErrorHandler: ServiceErrorHandler[F] = serviceErrorHandler,
       banner: List[String] = banner
   ): Self =
-    new ArmeriaServerBuilder(addServices, socketAddress, serviceErrorHandler, banner)
-
-  private def atBuild(f: ArmeriaBuilder => ArmeriaBuilder): Self =
-    copy(addServices = (armeriaBuilder, dispatcher) =>
-      addServices(armeriaBuilder, dispatcher).map(f))
+    new ArmeriaServerBuilder(armeriaServerBuilder, socketAddress, serviceErrorHandler, banner)
 }
 
 trait ArmeriaServer extends Server {
@@ -346,13 +369,19 @@ trait ArmeriaServer extends Server {
 
 /** A builder that builds Armeria server for Http4s. */
 object ArmeriaServerBuilder {
-  type AddServices[F[_]] = (ArmeriaBuilder, Dispatcher[F]) => F[ArmeriaBuilder]
 
   /** Returns a newly created [[org.http4s.armeria.server.ArmeriaServerBuilder]]. */
-  def apply[F[_]: Async]: ArmeriaServerBuilder[F] =
+  def apply[F[_]: ConcurrentEffect]: ArmeriaServerBuilder[F] = {
+    val defaultServerBuilder =
+      BackendServer
+        .builder()
+        .idleTimeoutMillis(IdleTimeout.toMillis)
+        .requestTimeoutMillis(ResponseTimeout.toMillis)
+        .gracefulShutdownTimeoutMillis(ShutdownTimeout.toMillis, ShutdownTimeout.toMillis)
     new ArmeriaServerBuilder(
-      (armeriaBuilder, _) => armeriaBuilder.pure,
+      armeriaServerBuilder = defaultServerBuilder,
       socketAddress = defaults.IPv4SocketAddress,
       serviceErrorHandler = DefaultServiceErrorHandler,
       banner = defaults.Banner)
+  }
 }

--- a/server/src/test/scala/org/http4s/armeria/server/ArmeriaServerBuilderSuite.scala
+++ b/server/src/test/scala/org/http4s/armeria/server/ArmeriaServerBuilderSuite.scala
@@ -18,8 +18,8 @@ package org.http4s.armeria.server
 
 import java.net.{HttpURLConnection, URL}
 import java.nio.charset.StandardCharsets
-
-import cats.effect.{Deferred, IO}
+import cats.effect.IO
+import cats.effect.concurrent.Deferred
 import cats.implicits._
 import com.linecorp.armeria.client.logging.LoggingClient
 import com.linecorp.armeria.client.{ClientFactory, WebClient}


### PR DESCRIPTION
This is a preparation for a 'courtesy' release based on http4s 0.22.14 (and Cats-Effect 2). I've created a new branch `series/0.2` (it shouldn't be merged to `main`!) just like we do in http4s. Why this is needed? Well, because many users are still on Cats-Effect 2 and can't invest in migration to Cats-Effect 3, but wants to get new functionality of http4s. I believe this is a one-time story, we'll publish `0.2.1` and can remove the `series/0.2` branch.