### PR TITLE
Pin `logback-classic` updates to 1.2.x series

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,3 @@
+updates.pin = [
+  { groupId = "ch.qos.logback", artifactId = "logback-classic", version = "1.2." }
+]


### PR DESCRIPTION
The new `1.4.x` series brings slf4j `2.0`, so in http4s we decided to [pin updates](https://github.com/http4s/http4s/pull/6646) of the `logback-classic` to the `1.2.x` series. I think here we should do the same.