### PR TITLE
Upgrade to http4s `v0.23.22`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,7 @@ ThisBuild / Test / javaOptions += "-Dcom.linecorp.armeria.verboseResponses=true 
 val versions = new {
   val armeria = "1.23.1"
   val fs2 = "3.6.1"
-  val http4s = "0.23.18"
+  val http4s = "0.23.19"
   val logback = "1.2.12"
   val micrometer = "1.9.2"
   val munit = "0.7.29"

--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,7 @@ ThisBuild / Test / javaOptions += "-Dcom.linecorp.armeria.verboseResponses=true 
 
 val versions = new {
   val armeria = "1.23.1"
-  val fs2 = "3.6.1"
+  val fs2 = "3.7.0"
   val http4s = "0.23.19"
   val logback = "1.2.12"
   val micrometer = "1.9.2"

--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,7 @@ ThisBuild / Test / javaOptions += "-Dcom.linecorp.armeria.verboseResponses=true 
 val versions = new {
   val armeria = "1.24.2"
   val fs2 = "3.7.0"
-  val http4s = "0.23.19"
+  val http4s = "0.23.22"
   val logback = "1.2.12"
   val micrometer = "1.9.2"
   val munit = "0.7.29"

--- a/client/src/main/scala/org/http4s/armeria/client/ArmeriaClient.scala
+++ b/client/src/main/scala/org/http4s/armeria/client/ArmeriaClient.scala
@@ -27,17 +27,15 @@ import com.linecorp.armeria.common.{
   HttpMethod,
   HttpRequest,
   HttpResponse,
-  RequestHeaders,
-  ResponseHeaders
+  RequestHeaders
 }
 import fs2.interop.reactivestreams._
 import fs2.{Chunk, Stream}
 import cats.effect.kernel.{Async, MonadCancel}
+import cats.effect.syntax.all._
 import org.http4s.client.Client
 import org.http4s.internal.CollectionCompat.CollectionConverters._
 import org.typelevel.ci.CIString
-
-import java.util.concurrent.{CancellationException, CompletableFuture, CompletionException}
 
 private[armeria] final class ArmeriaClient[F[_]] private[client] (
     private val client: WebClient
@@ -93,7 +91,9 @@ private[armeria] final class ArmeriaClient[F[_]] private[client] (
   private def toResponse(response: HttpResponse): F[Response[F]] = {
     val splitResponse = response.split()
     for {
-      headers <- fromCompletableFuture(splitResponse.headers)
+      headers <- F
+        .fromCompletableFuture(F.delay(splitResponse.headers))
+        .cancelable(F.delay(response.abort()))
       status <- F.fromEither(Status.fromInt(headers.status().code()))
       body =
         splitResponse
@@ -102,23 +102,6 @@ private[armeria] final class ArmeriaClient[F[_]] private[client] (
           .flatMap(x => Stream.chunk(Chunk.array(x.array())))
     } yield Response(status = status, headers = toHeaders(headers), body = body)
   }
-
-  private def fromCompletableFuture(cf: => CompletableFuture[ResponseHeaders]): F[ResponseHeaders] =
-    F.async { cb =>
-      cf.handle[Unit] { (result: ResponseHeaders, err: Throwable) =>
-        err match {
-          case null =>
-            cb(Right(result))
-          case _: CancellationException =>
-            ()
-          case ex: CompletionException if ex.getCause ne null =>
-            cb(Left(ex.getCause))
-          case ex =>
-            cb(Left(ex))
-        }
-      }
-      F.delay(Some(F.delay(cf.cancel(true)).void))
-    }
 
   /** Converts Armeria's [[com.linecorp.armeria.common.HttpHeaders]] to http4s' [[Headers]]. */
   private def toHeaders(req: HttpHeaders): Headers =

--- a/client/src/test/scala/org/http4s/armeria/client/ArmeriaClientSuite.scala
+++ b/client/src/test/scala/org/http4s/armeria/client/ArmeriaClientSuite.scala
@@ -76,7 +76,7 @@ class ArmeriaClientSuite extends CatsEffectSuite {
             val response = HttpResponse.from(
               req
                 .aggregate()
-                .thenApply(agg => HttpResponse.of(s"Hello, ${agg.contentUtf8()}!")))
+                .thenApply[HttpResponse](agg => HttpResponse.of(s"Hello, ${agg.contentUtf8()}!")))
             HttpResponse.delayed(response, java.time.Duration.ofSeconds(1))
           }
         }

--- a/client/src/test/scala/org/http4s/armeria/client/ArmeriaClientSuite.scala
+++ b/client/src/test/scala/org/http4s/armeria/client/ArmeriaClientSuite.scala
@@ -73,11 +73,11 @@ class ArmeriaClientSuite extends CatsEffectSuite {
         "/delayed",
         new HttpService {
           override def serve(ctx: ServiceRequestContext, req: HttpRequest): HttpResponse = {
-            Thread.sleep(1000)
-            HttpResponse.from(
+            val response = HttpResponse.from(
               req
                 .aggregate()
                 .thenApply(agg => HttpResponse.of(s"Hello, ${agg.contentUtf8()}!")))
+            HttpResponse.delayed(response, java.time.Duration.ofSeconds(1))
           }
         }
       )

--- a/server/src/main/scala/org/http4s/armeria/server/ArmeriaHttp4sHandler.scala
+++ b/server/src/main/scala/org/http4s/armeria/server/ArmeriaHttp4sHandler.scala
@@ -69,7 +69,7 @@ private[armeria] class ArmeriaHttp4sHandler[F[_]](
     val responseWriter = HttpResponse.streaming()
     dispatcher.unsafeRunAndForget(
       toRequest(ctx, req)
-        .fold(onParseFailure(_, responseWriter), handleRequest(_, responseWriter))
+        .fold(onParseFailure(_, ctx, responseWriter), handleRequest(_, ctx, responseWriter))
         .handleError { ex =>
           discardReturn(responseWriter.close(ex))
         }
@@ -77,18 +77,27 @@ private[armeria] class ArmeriaHttp4sHandler[F[_]](
     responseWriter
   }
 
-  private def handleRequest(request: Request[F], writer: HttpResponseWriter): F[Unit] =
+  private def handleRequest(
+      request: Request[F],
+      ctx: ServiceRequestContext,
+      writer: HttpResponseWriter): F[Unit] =
     serviceFn(request)
       .recoverWith(serviceErrorHandler(request))
-      .flatMap(toHttpResponse(_, writer))
+      .flatMap(toHttpResponse(_, ctx, writer))
 
-  private def onParseFailure(parseFailure: ParseFailure, writer: HttpResponseWriter): F[Unit] = {
+  private def onParseFailure(
+      parseFailure: ParseFailure,
+      ctx: ServiceRequestContext,
+      writer: HttpResponseWriter): F[Unit] = {
     val response = Response[F](Status.BadRequest).withEntity(parseFailure.sanitized)
-    toHttpResponse(response, writer)
+    toHttpResponse(response, ctx, writer)
   }
 
   /** Converts http4s' [[Response]] to Armeria's [[HttpResponse]]. */
-  private def toHttpResponse(response: Response[F], writer: HttpResponseWriter): F[Unit] = {
+  private def toHttpResponse(
+      response: Response[F],
+      ctx: ServiceRequestContext,
+      writer: HttpResponseWriter): F[Unit] = {
     val headers = toHttpHeaders(response.headers, response.status.some)
     writer.write(headers)
     val body = response.body
@@ -106,7 +115,7 @@ private[armeria] class ArmeriaHttp4sHandler[F[_]](
           maybeWriteTrailersAndClose(writer, response)
         }
     else
-      writeOnDemand(writer, body).stream
+      writeOnDemand(writer, ctx, body).stream
         .onFinalize(maybeWriteTrailersAndClose(writer, response))
         .compile
         .drain
@@ -123,6 +132,7 @@ private[armeria] class ArmeriaHttp4sHandler[F[_]](
 
   private def writeOnDemand(
       writer: HttpResponseWriter,
+      ctx: ServiceRequestContext,
       body: Stream[F, Byte]): Pull[F, Nothing, Unit] =
     body.pull.uncons.flatMap {
       case Some((head, tail)) =>
@@ -134,9 +144,9 @@ private[armeria] class ArmeriaHttp4sHandler[F[_]](
           Pull.eval(F.async[Unit] { cb =>
             F.delay(discardReturn(writer.whenConsumed().thenRun(() => cb(RightUnit))))
               .as(Some(F.delay(
-                writer.close()
+                ctx.cancel()
               )))
-          }) >> writeOnDemand(writer, tail)
+          }) >> writeOnDemand(writer, ctx, tail)
       case None =>
         Pull.done
     }

--- a/server/src/main/scala/org/http4s/armeria/server/ArmeriaHttp4sHandler.scala
+++ b/server/src/main/scala/org/http4s/armeria/server/ArmeriaHttp4sHandler.scala
@@ -133,8 +133,11 @@ private[armeria] class ArmeriaHttp4sHandler[F[_]](
         if (tail == Stream.empty)
           Pull.done
         else
-          Pull.eval(F.async_[Unit] { cb =>
-            discardReturn(writer.whenConsumed().thenRun(() => cb(RightUnit)))
+          Pull.eval(F.async[Unit] { cb =>
+            F.delay(discardReturn(writer.whenConsumed().thenRun(() => cb(RightUnit))))
+              .as(Some(F.delay(
+                writer.close()
+              )))
           }) >> writeOnDemand(writer, tail)
       case None =>
         Pull.done

--- a/server/src/main/scala/org/http4s/armeria/server/ArmeriaServerBuilder.scala
+++ b/server/src/main/scala/org/http4s/armeria/server/ArmeriaServerBuilder.scala
@@ -313,6 +313,7 @@ sealed class ArmeriaServerBuilder[F[_]] private (
   def withMeterRegistry(meterRegistry: MeterRegistry): Self =
     atBuild(_.meterRegistry(meterRegistry))
 
+  // Note this effect became uncancelable since Cats-Effect 3.5.0
   private def shutdown(armeriaServer: BackendServer): F[Unit] =
     F.async_[Unit] { cb =>
       val _ = armeriaServer

--- a/server/src/main/scala/org/http4s/armeria/server/ArmeriaServerBuilder.scala
+++ b/server/src/main/scala/org/http4s/armeria/server/ArmeriaServerBuilder.scala
@@ -313,18 +313,8 @@ sealed class ArmeriaServerBuilder[F[_]] private (
   def withMeterRegistry(meterRegistry: MeterRegistry): Self =
     atBuild(_.meterRegistry(meterRegistry))
 
-  // Note this effect became uncancelable since Cats-Effect 3.5.0
   private def shutdown(armeriaServer: BackendServer): F[Unit] =
-    F.async_[Unit] { cb =>
-      val _ = armeriaServer
-        .stop()
-        .whenComplete { (_, cause) =>
-          if (cause == null)
-            cb(Right(()))
-          else
-            cb(Left(cause))
-        }
-    }
+    F.fromCompletableFuture(F.delay(armeriaServer.stop())).void
 
   override def withBanner(banner: immutable.Seq[String]): Self = copy(banner = banner.toList)
 


### PR DESCRIPTION
This PR transitively brings an update of Cats-Effect to `v3.5.0`. In turn, the semantics of cancelation was changed in CE, see https://github.com/typelevel/cats-effect/releases/tag/v3.5.0. Given that, this PR addresses the mentioned changes.