### PR TITLE
Migrate http4s to `1.0.0-M40` version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,8 +22,9 @@ ThisBuild / Test / javaOptions += "-Dcom.linecorp.armeria.verboseResponses=true 
 
 val versions = new {
   val armeria = "1.24.2"
-  val fs2 = "3.6.1"
-  val http4s = "1.0.0-M39"
+  val fs2 = "3.7.0"
+  val http4s = "1.0.0-M40"
+  val log4cats = "2.6.0"
   val logback = "1.2.12"
   val micrometer = "1.9.2"
   val munit = "0.7.29"

--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,6 @@ val versions = new {
   val armeria = "1.24.2"
   val fs2 = "3.7.0"
   val http4s = "1.0.0-M40"
-  val log4cats = "2.6.0"
   val logback = "1.2.12"
   val micrometer = "1.9.2"
   val munit = "0.7.29"

--- a/server/src/main/scala/org/http4s/armeria/server/ArmeriaServerBuilder.scala
+++ b/server/src/main/scala/org/http4s/armeria/server/ArmeriaServerBuilder.scala
@@ -98,7 +98,8 @@ sealed class ArmeriaServerBuilder[F[_]] private (
 
                 val armeriaVersion = Version.get("armeria").artifactVersion()
 
-                logger.info(s"http4s v${BuildInfo.version} on Armeria v$armeriaVersion started")
+                dispatcher.unsafeRunSync(
+                  logger.info(s"http4s v${BuildInfo.version} on Armeria v$armeriaVersion started"))
               }
             })
             armeriaServer0.start().join()

--- a/server/src/test/scala/org/http4s/armeria/server/ServerFixture.scala
+++ b/server/src/test/scala/org/http4s/armeria/server/ServerFixture.scala
@@ -16,12 +16,14 @@
 
 package org.http4s.armeria.server
 
+import java.net.URI
+
 import cats.effect.{IO, Resource}
 import com.linecorp.armeria.common.SessionProtocol
 import com.linecorp.armeria.server.Server
-
-import java.net.URI
 import munit.{CatsEffectFunFixtures, CatsEffectSuite}
+import org.typelevel.log4cats.LoggerFactory
+import org.typelevel.log4cats.slf4j.Slf4jFactory
 
 import scala.concurrent.duration._
 import scala.util.Try
@@ -49,6 +51,8 @@ trait ServerFixture extends CatsEffectFunFixtures {
     "armeria-server-fixture",
     Resource.make(IO(setUp()))(_ => IO(tearDown()))
   )
+
+  private implicit val logging: LoggerFactory[IO] = Slf4jFactory.create[IO]
 
   private def setUp(): Unit = {
     val serverBuilder = ArmeriaServerBuilder[IO].withGracefulShutdownTimeout(0.seconds, 0.seconds)


### PR DESCRIPTION
Basically, I've ported the https://github.com/http4s/http4s-armeria/pull/335 to the `series/1.x` branch and supported changes from `1.0.0-M40`.