### PR TITLE
Add handling of `ContentTooLargeException` to the default service error handler

### DIFF
--- a/server/src/main/scala/org/http4s/armeria/server/ArmeriaServerBuilder.scala
+++ b/server/src/main/scala/org/http4s/armeria/server/ArmeriaServerBuilder.scala
@@ -364,7 +364,7 @@ object ArmeriaServerBuilder {
     new ArmeriaServerBuilder(
       (armeriaBuilder, _) => armeriaBuilder.pure,
       socketAddress = defaults.IPv4SocketAddress,
-      serviceErrorHandler = DefaultServiceErrorHandler,
+      serviceErrorHandler = defaultServiceErrorHandler[F],
       banner = defaults.Banner
     )
 

--- a/server/src/main/scala/org/http4s/armeria/server/ArmeriaServerBuilder.scala
+++ b/server/src/main/scala/org/http4s/armeria/server/ArmeriaServerBuilder.scala
@@ -368,8 +368,9 @@ object ArmeriaServerBuilder {
       banner = defaults.Banner
     )
 
-  /** Incorporates the default service error handling from Http4s' [[DefaultServiceErrorHandler]]
-    * and adds handling for some errors propagated from the Armeria side.
+  /** Incorporates the default service error handling from Http4s'
+    * [[org.http4s.server.DefaultServiceErrorHandler DefaultServiceErrorHandler]] and adds handling
+    * for some errors propagated from the Armeria side.
     */
   def defaultServiceErrorHandler[F[_]](implicit
       F: Monad[F]): Request[F] => PartialFunction[Throwable, F[Response[F]]] = {


### PR DESCRIPTION
Resolves #573